### PR TITLE
Count search results based on non-overlapping ranges

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -62,15 +62,40 @@ const displayNavigationCount = (element, count) => {
     }
 };
 
+const setOrDelete = (map, key, value) => {
+    if (value == null) {
+        map.delete(key);
+    } else {
+        map.set(key, value);
+    }
+};
+
 const populateNavigationCounts = async () => {
     const searchBack = document.getElementById('search-back');
     const searchNext = document.getElementById('search-next');
 
-    const response = await fetch(`/api-unstable/search/navigation-counts${window.location.search}`);
+    const params = new URLSearchParams(window.location.search);
+
+    const backid = searchBack && new URL(searchBack.href).searchParams.get('backid');
+    const nextid = searchNext && new URL(searchNext.href).searchParams.get('nextid');
+
+    setOrDelete(params, 'backid', backid);
+    setOrDelete(params, 'nextid', nextid);
+
+    const response = await fetch(`/api-unstable/search/navigation-counts?${params}`);
+    if (!response.ok) {
+        return;
+    }
+
     const {nextCount, backCount} = await response.json();
 
-    displayNavigationCount(searchBack, backCount);
-    displayNavigationCount(searchNext, nextCount);
+    if (searchBack) {
+        displayNavigationCount(searchBack, backCount);
+    }
+
+    if (searchNext) {
+        displayNavigationCount(searchNext, nextCount);
+    }
 };
 
 animateSearchSettings();

--- a/weasyl/controllers/general.py
+++ b/weasyl/controllers/general.py
@@ -66,11 +66,17 @@ def search_(request):
 
         if search_query.find == "user":
             query = search.select_users(q)
-            next_count = back_count = 0
         else:
             search_query.ratings.update(ratings.CHARACTER_MAP[rating_code].code for rating_code in meta["rated"])
 
-            query, next_count, back_count = search.select(
+            if backid:
+                page = search.PrevFilter(meta["backid"])
+            elif nextid:
+                page = search.NextFilter(meta["nextid"])
+            else:
+                page = search.FIRST_PAGE
+
+            query, prev_page, next_page = search.select(
                 userid=request.userid,
                 rating=rating,
                 limit=63,
@@ -78,8 +84,8 @@ def search_(request):
                 within=meta["within"],
                 cat=meta["cat"],
                 subcat=meta["subcat"],
-                backid=meta["backid"],
-                nextid=meta["nextid"])
+                page=page,
+            )
 
         title = "Search results"
         template_args = (
@@ -89,11 +95,10 @@ def search_(request):
             meta,
             # Search results
             query,
-            next_count,
-            back_count,
+            prev_page,
+            next_page,
             # Submission subcategories
             macro.MACRO_SUBCAT_LIST,
-            search.COUNT_LIMIT,
             # `browse_header`
             None,
             # `is_guest`
@@ -128,9 +133,11 @@ def search_(request):
             meta,
             # Search results
             query,
-            0,
-            0,
+            # `prev_page`
             None,
+            # `next_page`
+            None,
+            # `subcats`
             None,
             browse_header,
         )

--- a/weasyl/controllers/search.py
+++ b/weasyl/controllers/search.py
@@ -2,6 +2,12 @@ from pyramid.response import Response
 
 from libweasyl import ratings
 from weasyl import define, search
+from weasyl.forms import expect_id
+from weasyl.search import NextFilter
+from weasyl.search import PrevFilter
+
+
+RESULTS_PER_PAGE = 63
 
 
 def navigation_counts(request):
@@ -15,31 +21,19 @@ def navigation_counts(request):
     backid = request.GET.get('backid')
     nextid = request.GET.get('nextid')
 
-    def _search(counts: search.NavigationCountsSettings):
-        return search._find_without_media(
+    def _search(page: PrevFilter | NextFilter) -> int:
+        return search.select_count(
             userid=request.userid,
             rating=define.get_rating(request.userid),
-            limit=63,
             search=query,
             within=request.GET.get('within', ''),
             cat=int(cat) if cat else None,
             subcat=int(subcat) if subcat else None,
-            backid=int(backid) if backid else None,
-            nextid=int(nextid) if nextid else None,
-            counts=counts,
+            page=page,
         )
 
-    _, next_count, back_count = _search(search.NavigationCountsSettings(100, 100, 0))
-
-    if next_count == 100 or back_count == 100:
-        _, approx_next_count, approx_back_count = _search(search.NavigationCountsSettings(10, 90, 10))
-        next_count += approx_next_count
-        back_count += approx_back_count
-
-    if next_count == 1000 or back_count == 1000:
-        _, approx_next_count, approx_back_count = _search(search.NavigationCountsSettings(1, 90, 10))
-        next_count += approx_next_count
-        back_count += approx_back_count
+    back_count = None if backid is None else _search(PrevFilter(expect_id(backid)))
+    next_count = None if nextid is None else _search(NextFilter(expect_id(nextid)))
 
     counts = {
         'nextCount': next_count,

--- a/weasyl/search.py
+++ b/weasyl/search.py
@@ -1,5 +1,7 @@
-from collections import namedtuple
 import re
+from typing import Any
+from typing import Literal
+from typing import NamedTuple
 
 from libweasyl.ratings import GENERAL, MATURE, EXPLICIT
 
@@ -29,13 +31,6 @@ _TABLE_INFORMATION = {
     "char": (20, "f", "character", "charid", 3999),
     "journal": (30, "j", "journal", "journalid", 3999),
 }
-
-COUNT_LIMIT = 10000
-
-NavigationCountsSettings = namedtuple(
-    'NavigationCountsSettings',
-    ('sample_percent', 'sample_limit', 'sample_offset')
-)
 
 
 class Query:
@@ -140,21 +135,41 @@ def select_users(q):
     return ret
 
 
-def _find_without_media(userid, rating, limit,
-                        search, within, cat, subcat, backid, nextid,
-                        counts = NavigationCountsSettings(100, 0, 0)):
-    type_code, type_letter, table, select, subtype = _TABLE_INFORMATION[search.find]
+Results = list[dict[str, Any]]
+
+
+class _FirstPage:
+    __slots__ = ()
+
+
+FIRST_PAGE = _FirstPage()
+
+
+class PrevFilter(NamedTuple):
+    backid: int
+
+
+class NextFilter(NamedTuple):
+    nextid: int
+
+
+def _prepare_search(
+    *,
+    userid,
+    rating,
+    search,
+    within,
+    cat,
+    subcat,
+):
+    _type_code, type_letter, table, select, subtype = _TABLE_INFORMATION[search.find]
 
     # Begin statement
     statement_with = ""
-    statement_from_base = ["FROM {table} content"]
+    statement_from_base = "FROM {table} content"
     statement_from_join = ["INNER JOIN profile ON content.userid = profile.userid"]
     statement_where = ["WHERE content.rating <= %(rating)s AND NOT content.friends_only AND NOT content.hidden"]
     statement_group = []
-
-    if counts.sample_percent < 100:
-        # Use REPEATABLE to prevent the user from seeing different counts on refresh.
-        statement_from_base.append("TABLESAMPLE SYSTEM ({sample_percent}) REPEATABLE (0)")
 
     if search.find == "submit":
         statement_from_join.append("INNER JOIN submission_tags ON content.submitid = submission_tags.submitid")
@@ -265,11 +280,18 @@ def _find_without_media(userid, rating, limit,
         statement_from_join.append("INNER JOIN login login_exclude ON content.userid = login_exclude.userid")
         statement_where.append("AND login_exclude.login_name != ALL (%(required_user_excludes)s)")
 
-    def make_statement(statement_select, statement_additional_where, statement_order):
+    def make_statement(
+        statement_select,
+        statement_additional_where,
+        statement_order,
+        *,
+        tablesample="",
+    ):
         return " ".join([
             statement_with,
             statement_select,
-            " ".join(statement_from_base),
+            statement_from_base,
+            tablesample,
             " ".join(statement_from_join),
             " ".join(statement_where),
             statement_additional_where,
@@ -278,28 +300,11 @@ def _find_without_media(userid, rating, limit,
         ]).format(
             table=table,
             find=search.find,
-            sample_percent=counts.sample_percent,
-            sample_offset=counts.sample_offset,
             select=select,
             subtype=subtype,
             title_field="char_name" if search.find == "char" else "title",
             extra_fields=", content.settings" if search.find == "char" else ""
         )
-
-    pagination_filter = (
-        "AND content.{select} > %(backid)s" if backid else
-        "AND content.{select} < %(nextid)s" if nextid else
-        "")
-
-    statement = make_statement(
-        """
-        SELECT
-            content.{select}, content.{title_field} AS title, content.rating, content.unixtime, content.userid,
-            profile.username, {subtype} as subtype
-            {extra_fields}
-        """,
-        pagination_filter,
-        "ORDER BY content.{{select}} {order} LIMIT %(limit)s".format(order="" if backid else "DESC"))
 
     all_names = (
         search.possible_includes |
@@ -323,73 +328,154 @@ def _find_without_media(userid, rating, limit,
         "ratings": list(search.ratings),
         "category": cat,
         "subcategory": subcat,
-        "limit": limit,
-        "count_limit": counts.sample_limit,
-        "count_offset": counts.sample_offset,
-        "backid": backid,
-        "nextid": nextid,
         "required_include_count": len(search.required_includes),
     }
+
+    return make_statement, params
+
+
+def _find_without_media(
+    *,
+    userid,
+    rating,
+    limit: int,
+    search,
+    within,
+    cat,
+    subcat,
+    page: _FirstPage | PrevFilter | NextFilter,
+) -> tuple[Results, PrevFilter | None, NextFilter | None]:
+    type_code, _type_letter, _table, select, _subtype = _TABLE_INFORMATION[search.find]
+    make_statement, params = _prepare_search(
+        userid=userid,
+        rating=rating,
+        search=search,
+        within=within,
+        cat=cat,
+        subcat=subcat,
+    )
+
+    match page:
+        case PrevFilter(backid):
+            pagination_filter = "AND content.{select} > %(backid)s"
+            params["backid"] = backid
+            is_back = True
+        case NextFilter(nextid):
+            pagination_filter = "AND content.{select} < %(nextid)s"
+            params["nextid"] = nextid
+            is_back = False
+        case _:
+            assert page is FIRST_PAGE
+            pagination_filter = ""
+            is_back = False
+
+    statement = make_statement(
+        """
+        SELECT
+            content.{select}, content.{title_field} AS title, content.rating, content.unixtime, content.userid,
+            profile.username, {subtype} as subtype
+            {extra_fields}
+        """,
+        pagination_filter,
+        (
+            "ORDER BY content.{select}"
+            f"{'' if is_back else ' DESC'}"
+            f" LIMIT {limit + 1}"
+        ),
+    )
 
     query = d.engine.execute(statement, params)
 
     ret = [{"contype": type_code, **i} for i in query]
 
-    if params["count_limit"] == 0:
-        return list(reversed(ret)) if backid else ret, 0, 0
+    # Selected one more result than will be returned to check if there’s a next page in the queried direction.
+    has_more = len(ret) == limit + 1
+    if has_more:
+        del ret[-1]
 
-    if backid:
-        # backid is the item after the last item (display-order-wise) on the
-        # current page; the query will select items from there backwards,
-        # including the current page. Subtract the number of items on the
-        # current page to account for this, and add the maximum number of items
-        # on a page to the count limit so it still comes out to the count limit
-        # after subtracting if the limit is reached.
-        back_count = d.engine.scalar(
-            make_statement("SELECT 100 / {sample_percent} * COUNT(*) FROM (SELECT 1", pagination_filter, " LIMIT %(count_limit)s + %(limit)s OFFSET %(count_offset)s) _"),
-            params) - len(ret) * 100 / counts.sample_percent
-    elif nextid:
-        # nextid is the item before the first item (display-order-wise) on the
-        # current page; the query will select items from there backwards, so
-        # the current page is not included and no subtraction or modification
-        # of the limit is necessary.
-        back_count = d.engine.scalar(
-            make_statement("SELECT 100 / {sample_percent} * COUNT(*) FROM (SELECT 1", "AND content.{select} >= %(nextid)s", " LIMIT %(count_limit)s OFFSET %(count_offset)s) _"),
-            params)
-    else:
-        # The first page is being displayed; there’s nothing to go back to.
-        back_count = 0
+    if is_back:
+        ret.reverse()
 
-    if backid:
-        # backid is the item after the last item (display-order-wise) on the
-        # current page; the query will select items from there forwards, so the
-        # current page is not included and no subtraction or modification of
-        # the limit is necessary.
-        next_count = d.engine.scalar(
-            make_statement("SELECT 100 / {sample_percent} * COUNT(*) FROM (SELECT 1", "AND content.{select} <= %(backid)s", " LIMIT %(count_limit)s OFFSET %(count_offset)s) _"),
-            params)
-
-        # The ORDER BY is reversed when a backid is specified in order to LIMIT
-        # to the nearest items with a larger backid rather than the smallest
-        # ones, so reverse the items back to display order here.
-        return list(reversed(ret)), next_count, back_count
-    else:
-        # This is either the first page or a page based on a nextid. In both
-        # cases, the query will include the items in the current page in the
-        # count, so subtract the number of items on the current page to give a
-        # count of items after this page, and add the maximum number of items
-        # on a page to the count limit so it still comes out to the count limit
-        # after subtracting if the limit is reached.
-        next_count = d.engine.scalar(
-            make_statement("SELECT 100 / {sample_percent} * COUNT(*) FROM (SELECT 1", pagination_filter, " LIMIT %(count_limit)s + %(limit)s OFFSET %(count_offset)s) _"),
-            params) - len(ret) * 100 / counts.sample_percent
-
-        return ret, next_count, back_count
+    # A surrounding page is absent in any of these cases:
+    # - there are no results
+    # - `has_more` checked in that direction and returned a negative
+    # - it’s the back page of the first page
+    prev_page = (
+        None if page is FIRST_PAGE or ((not has_more) and is_back) or not ret
+        else PrevFilter(ret[0][select])
+    )
+    next_page = (
+        None if ((not has_more) and (not is_back)) or not ret
+        else NextFilter(ret[-1][select])
+    )
+    return ret, prev_page, next_page
 
 
-def select(**kwargs):
+def select_count(*, page: PrevFilter | NextFilter, **kwargs) -> int:
+    """
+    Get an approximate count of search results starting at some page.
+    """
+    make_statement, params = _prepare_search(**kwargs)
+
+    cont_key: Literal["backid", "nextid"]
+
+    # The PostgreSQL function that determines, from a result set of ids, the anchor for the next page in the same direction.
+    cont_func: Literal["max", "min"]
+
+    match page:
+        case PrevFilter(backid):
+            filter = "AND content.{select} > %(backid)s"
+            params[cont_key := "backid"] = backid
+            cont_func = "max"
+            order = ""
+        case NextFilter(nextid):
+            filter = "AND content.{select} < %(nextid)s"
+            params[cont_key := "nextid"] = nextid
+            cont_func = "min"
+            order = "DESC"
+        case _:  # pragma: no cover
+            raise TypeError("invalid page")
+
+    total_count = 0
+
+    # Count up to 100 results precisely.
+    count_limit = 100
+
+    for sample_percent in [100, 10, 1]:
+        sample_count, continuation = d.engine.execute(
+            make_statement(
+                (
+                    f"SELECT COUNT(*), {cont_func}(postid)"
+                    " FROM (SELECT content.{select} AS postid"
+                ),
+                filter,
+                (
+                    "ORDER BY content.{select}"
+                    f" {order} LIMIT {count_limit}"
+                    ") _"
+                ),
+                # Use REPEATABLE to prevent the user from seeing different counts on refresh.
+                tablesample=f" TABLESAMPLE SYSTEM ({sample_percent}) REPEATABLE (0)" if sample_percent < 100 else "",
+            ),
+            params,
+        ).one()
+
+        total_count += sample_count * (100 // sample_percent)
+
+        if sample_count < count_limit:
+            break
+
+        params[cont_key] = continuation
+
+        # Count up to 10 times as many results in total next round. The results so far will be 10% of that, and the next round will be the remaining 90% (100 * 10% + 90 = 100).
+        count_limit = 90
+
+    return total_count
+
+
+def select(**kwargs) -> tuple[Results, PrevFilter | None, NextFilter | None]:
     search = kwargs['search']
-    results, next_count, back_count = _find_without_media(**kwargs)
+    results, prev_page, next_page = _find_without_media(**kwargs)
 
     if search.find == 'submit':
         media.populate_with_submission_media(results)
@@ -400,7 +486,7 @@ def select(**kwargs):
     elif search.find == 'journal':
         media.populate_with_user_media(results)
 
-    return results, next_count, back_count
+    return results, prev_page, next_page
 
 
 def browse(userid, rating, limit, find, cat, backid, nextid):

--- a/weasyl/templates/etc/search.html
+++ b/weasyl/templates/etc/search.html
@@ -1,4 +1,4 @@
-$def with (method, meta, results, next_count=0, back_count=0, subcats=None, count_limit=None, browse_header=None, is_guest=None, rating_limit=None)
+$def with (method, meta, results, prev_page=None, next_page=None, subcats=None, browse_header=None, is_guest=None, rating_limit=None)
 $#:{TITLE("Weasyl Search")}
 $ _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
 $code:
@@ -104,8 +104,10 @@ $code:
         </ul>
 
         <nav id="search-nav" style="padding-top: 1.4em;" class="pad-left pad-right">
-          <a id="search-back" class="button" href="/search?${QUERY_STRING(dict(meta, backid=results[0][id_fields[meta['find']]], nextid=None))}" rel="prev">Back</a>
-          <a id="search-next" class="button" style="float:right;" href="/search?${QUERY_STRING(dict(meta, nextid=results[-1][id_fields[meta['find']]], backid=None))}" rel="next">Next</a>
+          $if prev_page is not None:
+            <a id="search-back" class="button" href="/search?${QUERY_STRING(dict(meta, backid=prev_page.backid, nextid=None))}" rel="prev">Back</a>
+          $if next_page is not None:
+            <a id="search-next" class="button" style="float:right;" href="/search?${QUERY_STRING(dict(meta, nextid=next_page.nextid, backid=None))}" rel="next">Next</a>
         </nav>
       $else:
         <p class="pad-left pad-right" style="padding-top: 2em;">There are no search results to display. You may want to <a class="color-a" href="/search">browse for content</a> or edit your search criteria.</p>


### PR DESCRIPTION
- Fixes a bug where the subtracting the scaled result size from the estimated count could produce a negative count and incorrectly remove valid navigation links, caused by the `OFFSET %(count_offset)s` applied before the subtraction. Also avoids relying on getting back stable results in general, fixing niche concurrency bugs that could have similar effects and removing the dependency on `REPEATABLE`.

- Fixes `/` division producing unintended (but still whole-number) float.

- Avoids rendering Back/Next links to empty pages for non-enhanced clients in most situations.

- Avoids running redundant queries:

    - skips re-fetching the unused concrete search results to produce the counts
    - counts each direction separately so one direction can run fewer queries than the other (or even zero)